### PR TITLE
Use Task.Run to better parallelize tasks

### DIFF
--- a/Rucksack.Tests/BasicIntegrationTests.cs
+++ b/Rucksack.Tests/BasicIntegrationTests.cs
@@ -17,7 +17,7 @@ public class BasicIntegrationTests(ITestOutputHelper testOutputHelper)
         await LoadTestRunner.Run(() =>
         {
             Interlocked.Increment(ref executionCount);
-            return ValueTask.CompletedTask;
+            return Task.CompletedTask;
         }, new LoadTestOptions
         {
             LoadStrategy = new OneShotLoadStrategy(count),
@@ -44,7 +44,7 @@ public class BasicIntegrationTests(ITestOutputHelper testOutputHelper)
         await LoadTestRunner.Run(() =>
         {
             Interlocked.Increment(ref executionCount);
-            return ValueTask.CompletedTask;
+            return Task.CompletedTask;
         }, new LoadTestOptions
         {
             LoadStrategy = new RepeatLoadStrategy(count, interval, duration),
@@ -55,6 +55,31 @@ public class BasicIntegrationTests(ITestOutputHelper testOutputHelper)
         });
 
         executionCount.Should().Be(count * durationSeconds / intervalSeconds);
+    }
+
+    [Fact]
+    public async Task BasicSteppedBurstIntegrationTest()
+    {
+        int executionCount = 0;
+        const int step = 10;
+        const int from = 10;
+        const int to = 50;
+        const int expected = 150; // 10 + 20 + 30 + 40 + 50
+
+        await LoadTestRunner.Run(() =>
+        {
+            Interlocked.Increment(ref executionCount);
+            return Task.CompletedTask;
+        }, new LoadTestOptions
+        {
+            LoadStrategy = new SteppedBurstLoadStrategy(step, from, to, FromSeconds(1)),
+            LoggerFactory = LoggerFactory.Create(builder =>
+            {
+                builder.AddXUnit(testOutputHelper);
+            }),
+        });
+
+        executionCount.Should().Be(expected);
     }
 
     [Fact]

--- a/Rucksack.Tests/Strategies/OneShotLoadStrategyTests.cs
+++ b/Rucksack.Tests/Strategies/OneShotLoadStrategyTests.cs
@@ -17,7 +17,7 @@ public class OneShotLoadStrategyTests
         var result = strategy.GenerateLoad(() =>
         {
             Interlocked.Increment(ref actionCalledCount);
-            return ValueTask.FromResult(new LoadTaskResult(TimeSpan.Zero));
+            return Task.FromResult(new LoadTaskResult(TimeSpan.Zero));
         }, context);
 
         await StrategyTestHelper.ExecuteStrategyResultAndWait(result);
@@ -39,7 +39,7 @@ public class OneShotLoadStrategyTests
         var result = strategy.GenerateLoad(() =>
         {
             Interlocked.Increment(ref actionCalledCount);
-            return ValueTask.FromResult(new LoadTaskResult(TimeSpan.Zero));
+            return Task.FromResult(new LoadTaskResult(TimeSpan.Zero));
         }, context);
 
         await StrategyTestHelper.ExecuteStrategyResultAndWait(result);

--- a/Rucksack.Tests/Strategies/RepeatLoadStrategyTests.cs
+++ b/Rucksack.Tests/Strategies/RepeatLoadStrategyTests.cs
@@ -11,10 +11,10 @@ public class RepeatLoadStrategyTests
         // Arrange
         var actionCalledCount = 0;
         var strategy = new RepeatLoadStrategy(1, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
-        var action = () =>
+        LoadTask action = () =>
         {
             Interlocked.Increment(ref actionCalledCount);
-            return ValueTask.FromResult(new LoadTaskResult(TimeSpan.Zero));
+            return Task.FromResult(new LoadTaskResult(TimeSpan.Zero));
         };
         var context = new LoadStrategyContext(PreviousResult: null);
 
@@ -30,7 +30,7 @@ public class RepeatLoadStrategyTests
         result = strategy.GenerateLoad(action, new LoadStrategyContext(PreviousResult: result));
 
         tasks.AddRange(await StrategyTestHelper.ExecuteStrategyResult(result));
-        await StrategyTestHelper.WhenAll(tasks);
+        await Task.WhenAll(tasks);
 
         // Assert
         actionCalledCount.Should().Be(1);
@@ -43,10 +43,10 @@ public class RepeatLoadStrategyTests
         // Arrange
         var actionCalledCount = 0;
         var strategy = new RepeatLoadStrategy(3, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
-        var action = () =>
+        LoadTask action = () =>
         {
             Interlocked.Increment(ref actionCalledCount);
-            return ValueTask.FromResult(new LoadTaskResult(TimeSpan.Zero));
+            return Task.FromResult(new LoadTaskResult(TimeSpan.Zero));
         };
         var context = new LoadStrategyContext(PreviousResult: null);
 
@@ -62,7 +62,7 @@ public class RepeatLoadStrategyTests
         result = strategy.GenerateLoad(action, new LoadStrategyContext(PreviousResult: result));
 
         tasks.AddRange(await StrategyTestHelper.ExecuteStrategyResult(result));
-        await StrategyTestHelper.WhenAll(tasks);
+        await Task.WhenAll(tasks);
 
         // Assert
         actionCalledCount.Should().Be(3);

--- a/Rucksack.Tests/Strategies/StrategyTestHelper.cs
+++ b/Rucksack.Tests/Strategies/StrategyTestHelper.cs
@@ -2,28 +2,22 @@ namespace Rucksack.Tests.Strategies;
 
 public static class StrategyTestHelper
 {
-    public static async ValueTask ExecuteStrategyResultAndWait(LoadStrategyResult result)
+    public static async Task ExecuteStrategyResultAndWait(LoadStrategyResult result)
     {
         var tasks = await ExecuteStrategyResult(result);
 
-        await WhenAll(tasks);
+        await Task.WhenAll(tasks);
     }
 
-    public static async ValueTask WhenAll(IEnumerable<ValueTask<LoadTaskResult>> tasks)
+    public static async Task<List<Task<LoadTaskResult>>> ExecuteStrategyResult(LoadStrategyResult result)
     {
-        foreach (var task in tasks)
-        {
-            await task;
-        }
-    }
+        var tasks = result.Tasks?.Select(i => Task.Run(() => i())).ToList() ?? [];
 
-    public static async ValueTask<List<ValueTask<LoadTaskResult>>> ExecuteStrategyResult(LoadStrategyResult result)
-    {
         if (result.RepeatDelay.HasValue)
         {
             await Task.Delay(result.RepeatDelay.Value);
         }
 
-        return [..result.Tasks ?? []];
+        return tasks;
     }
 }

--- a/Rucksack/ILoadStrategy.cs
+++ b/Rucksack/ILoadStrategy.cs
@@ -2,5 +2,5 @@ namespace Rucksack;
 
 public interface ILoadStrategy
 {
-    LoadStrategyResult GenerateLoad(Func<ValueTask<LoadTaskResult>> action, LoadStrategyContext context);
+    LoadStrategyResult GenerateLoad(LoadTask action, LoadStrategyContext context);
 }

--- a/Rucksack/LoadStrategies/OneShotLoadStrategy.cs
+++ b/Rucksack/LoadStrategies/OneShotLoadStrategy.cs
@@ -2,16 +2,14 @@ namespace Rucksack.LoadStrategies;
 
 public class OneShotLoadStrategy(int count) : ILoadStrategy
 {
-    public LoadStrategyResult GenerateLoad(Func<ValueTask<LoadTaskResult>> action, LoadStrategyContext context)
+    public LoadStrategyResult GenerateLoad(LoadTask action, LoadStrategyContext context)
     {
         if (context.PreviousResult is not null)
         {
             throw new InvalidOperationException("OneShotLoadStrategy does not support previous results.");
         }
 
-        var tasks = Enumerable.Range(0, count)
-            .Select(_ => action())
-            .ToArray();
+        var tasks = Enumerable.Repeat(action, count).ToArray();
 
         return new LoadStrategyResult(RepeatDelay: null, Tasks: tasks);
     }

--- a/Rucksack/LoadStrategies/RepeatLoadStrategy.cs
+++ b/Rucksack/LoadStrategies/RepeatLoadStrategy.cs
@@ -5,7 +5,7 @@ namespace Rucksack.LoadStrategies;
 public class RepeatLoadStrategy(int countPerInterval, TimeSpan interval, TimeSpan totalDuration)
     : ILoadStrategy
 {
-    public LoadStrategyResult GenerateLoad(Func<ValueTask<LoadTaskResult>> action, LoadStrategyContext context)
+    public LoadStrategyResult GenerateLoad(LoadTask action, LoadStrategyContext context)
     {
         RepeatLoadStrategyResult result;
         int iteration = 1;
@@ -29,9 +29,7 @@ public class RepeatLoadStrategy(int countPerInterval, TimeSpan interval, TimeSpa
             return LoadStrategyResult.Finished;
         }
 
-        var tasks = Enumerable.Range(0, countPerInterval)
-            .Select(_ => action())
-            .ToArray();
+        var tasks = Enumerable.Repeat(action, countPerInterval).ToArray();
 
         return result with
         {
@@ -40,6 +38,6 @@ public class RepeatLoadStrategy(int countPerInterval, TimeSpan interval, TimeSpa
         };
     }
 
-    private record RepeatLoadStrategyResult(TimeSpan? RepeatDelay, Stopwatch Stopwatch, int Iteration, IReadOnlyList<ValueTask<LoadTaskResult>>? Tasks)
+    private record RepeatLoadStrategyResult(TimeSpan? RepeatDelay, Stopwatch Stopwatch, int Iteration, IReadOnlyList<LoadTask>? Tasks)
         : LoadStrategyResult(RepeatDelay, Tasks);
 }

--- a/Rucksack/LoadStrategies/SteppedBurstLoadStrategy.cs
+++ b/Rucksack/LoadStrategies/SteppedBurstLoadStrategy.cs
@@ -33,7 +33,7 @@ public class SteppedBurstLoadStrategy : ILoadStrategy
         _interval = interval;
     }
 
-    public LoadStrategyResult GenerateLoad(Func<ValueTask<LoadTaskResult>> action, LoadStrategyContext context)
+    public LoadStrategyResult GenerateLoad(LoadTask action, LoadStrategyContext context)
     {
         SteppedLoadStrategyResult result;
         int currentCount = _from;
@@ -52,9 +52,7 @@ public class SteppedBurstLoadStrategy : ILoadStrategy
             currentCount = result.CurrentCount + _step;
         }
 
-        var tasks = Enumerable.Range(0, currentCount)
-            .Select(_ => action())
-            .ToArray();
+        var tasks = Enumerable.Repeat(action, currentCount).ToArray();
 
         return result with
         {
@@ -68,6 +66,6 @@ public class SteppedBurstLoadStrategy : ILoadStrategy
         (from < to && currentCount >= to)
         || (from > to && currentCount <= to);
 
-    private record SteppedLoadStrategyResult(TimeSpan? RepeatDelay, int CurrentCount, IReadOnlyList<ValueTask<LoadTaskResult>>? Tasks)
+    private record SteppedLoadStrategyResult(TimeSpan? RepeatDelay, int CurrentCount, IReadOnlyList<LoadTask>? Tasks)
         : LoadStrategyResult(RepeatDelay, Tasks);
 }

--- a/Rucksack/LoadStrategyResult.cs
+++ b/Rucksack/LoadStrategyResult.cs
@@ -1,6 +1,6 @@
 namespace Rucksack;
 
-public record LoadStrategyResult(TimeSpan? RepeatDelay, IReadOnlyList<ValueTask<LoadTaskResult>>? Tasks)
+public record LoadStrategyResult(TimeSpan? RepeatDelay, IReadOnlyList<LoadTask>? Tasks)
 {
     public static LoadStrategyResult Finished { get; } = new(null, null);
 }

--- a/Rucksack/LoadTask.cs
+++ b/Rucksack/LoadTask.cs
@@ -1,0 +1,3 @@
+namespace Rucksack;
+
+public delegate Task<LoadTaskResult> LoadTask();

--- a/Rucksack/LoadTestRunner.cs
+++ b/Rucksack/LoadTestRunner.cs
@@ -9,10 +9,10 @@ public static class LoadTestRunner
         Run(() =>
         {
             action();
-            return ValueTask.CompletedTask;
+            return Task.CompletedTask;
         }, options).Wait();
 
-    public static async Task Run(Func<ValueTask> action, LoadTestOptions options)
+    public static async Task Run(Func<Task> action, LoadTestOptions options)
     {
         var loggerFactory = options.LoggerFactory ?? LoggerFactory.Create(builder =>
         {
@@ -24,7 +24,7 @@ public static class LoadTestRunner
         logger.LogInformation("Rucksack is running...");
 
         LoadStrategyResult? result = null;
-        List<ValueTask<LoadTaskResult>> allTasks = [];
+        List<Task<LoadTaskResult>> allTasks = [];
 
         while (true)
         {
@@ -36,7 +36,7 @@ public static class LoadTestRunner
             {
                 logger.LogDebug("Enqueueing {Count} new tasks", tasks.Count);
 
-                allTasks.AddRange(tasks);
+                allTasks.AddRange(tasks.Select(task => Task.Run(() => task())));
             }
 
             if (result.RepeatDelay == null)
@@ -87,7 +87,7 @@ public static class LoadTestRunner
 
         return;
 
-        async ValueTask<LoadTaskResult> LoadAction()
+        async Task<LoadTaskResult> LoadAction()
         {
             var stopwatch = Stopwatch.StartNew();
 


### PR DESCRIPTION
The prior code would run tasks sequentially up until the first `await`, this should better parallelize the tasks by invoking them with `Task.Run`. 

This also moves from using `ValueTask` to using `Task`, as there is no `ValueTask.Run` equivalent. This was also probably a premature optimization.

In order to not have to repeat the `Task.Run` in each strategy, this change makes the strategy return a list of delegates rather than a list of Tasks, and the runner then invokes the delegate via `Task.Run`.